### PR TITLE
Fixed SpritesheetMovieClip:__goto when using frame label //patch

### DIFF
--- a/spritesheet/SpritesheetMovieClip.hx
+++ b/spritesheet/SpritesheetMovieClip.hx
@@ -152,7 +152,8 @@ class SpritesheetMovieClip extends openfl.display.MovieClip {
            targetFrame = frame;
         } else if (Std.is (frame, String)) {
             if(clip.currentBehavior != null) {
-                targetFrame= clip.spritesheet.getBehaviorFrameIndexFromLabel(clip.currentBehavior, frame);
+                targetFrame = clip.spritesheet.getBehaviorFrameIndexFromLabel(clip.currentBehavior, frame);
+                targetFrame += 1;
             }
         }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/spritesheet/17)
<!-- Reviewable:end -->
